### PR TITLE
correct example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ npm install -s bn-chai
 ## Setup
 ```javascript
 var chai = require('chai');
+var expect = chai.expect;
 var BN = require('bn.js');
 var bnChai = require('bn-chai');
 chai.use(bnChai(BN));


### PR DESCRIPTION
Without defining `expect`, we still rely on the expect variable defined by truffle and the bn extensions are not available

Cheers from ETHBerlin 😄 